### PR TITLE
Remove extra '.' in file extensions for code-gen'd filename

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -273,7 +273,7 @@ impl SyncSession {
                 CodegenKind::None => {}
                 CodegenKind::AssetUrl => {
                     if let Some(id) = asset.manifest_entry.uploaded_id {
-                        let path = &asset.path.with_extension(".lua");
+                        let path = &asset.path.with_extension("lua");
                         let contents = format!("return \"rbxassetid://{}\"", id);
 
                         fs::write(path, contents).context(error::Io { path })?;
@@ -286,7 +286,7 @@ impl SyncSession {
                 }
                 CodegenKind::Slice => {
                     if let Some(id) = asset.manifest_entry.uploaded_id {
-                        let path = &asset.path.with_extension(".lua");
+                        let path = &asset.path.with_extension("lua");
 
                         let contents = match &asset.manifest_entry.uploaded_subslice {
                             Some(slice) => format!(


### PR DESCRIPTION
Fixes #2.

There was a `.` character in the extensions we're adding to the code-generated files. the `with_extension` method on Path already includes this for us, so we were adding a duplicate.