### PR TITLE
Implement 'tarmac asset-list'

### DIFF
--- a/src/commands/asset_list.rs
+++ b/src/commands/asset_list.rs
@@ -9,7 +9,7 @@ use crate::options::{AssetListOptions, GlobalOptions};
 
 pub fn asset_list(_global: GlobalOptions, options: AssetListOptions) -> anyhow::Result<()> {
     let project_path = match options.project_path {
-        Some(path) => path.clone(),
+        Some(path) => path,
         None => env::current_dir()?,
     };
 

--- a/src/commands/asset_list.rs
+++ b/src/commands/asset_list.rs
@@ -1,0 +1,32 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::io::{BufWriter, Write};
+
+use fs_err as fs;
+
+use crate::data::Manifest;
+use crate::options::{AssetListOptions, GlobalOptions};
+
+pub fn asset_list(global: GlobalOptions, options: AssetListOptions) -> anyhow::Result<()> {
+    let project_path = match options.project_path {
+        Some(path) => path.clone(),
+        None => env::current_dir()?,
+    };
+
+    let manifest = Manifest::read_from_folder(&project_path)?;
+
+    let mut asset_list = BTreeSet::new();
+    for (name, input_manifest) in &manifest.inputs {
+        if let Some(id) = input_manifest.id {
+            asset_list.insert(id);
+        }
+    }
+
+    let mut file = BufWriter::new(fs::File::create(&options.output)?);
+    for id in asset_list {
+        writeln!(file, "{}", id)?;
+    }
+    file.flush()?;
+
+    Ok(())
+}

--- a/src/commands/asset_list.rs
+++ b/src/commands/asset_list.rs
@@ -7,7 +7,7 @@ use fs_err as fs;
 use crate::data::Manifest;
 use crate::options::{AssetListOptions, GlobalOptions};
 
-pub fn asset_list(global: GlobalOptions, options: AssetListOptions) -> anyhow::Result<()> {
+pub fn asset_list(_global: GlobalOptions, options: AssetListOptions) -> anyhow::Result<()> {
     let project_path = match options.project_path {
         Some(path) => path.clone(),
         None => env::current_dir()?,
@@ -16,7 +16,7 @@ pub fn asset_list(global: GlobalOptions, options: AssetListOptions) -> anyhow::R
     let manifest = Manifest::read_from_folder(&project_path)?;
 
     let mut asset_list = BTreeSet::new();
-    for (name, input_manifest) in &manifest.inputs {
+    for input_manifest in manifest.inputs.values() {
         if let Some(id) = input_manifest.id {
             asset_list.insert(id);
         }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,9 @@
+mod asset_list;
 mod create_cache_map;
 mod sync;
 mod upload_image;
 
+pub use asset_list::*;
 pub use create_cache_map::*;
 pub use sync::*;
 pub use upload_image::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn run(options: Options) -> Result<(), anyhow::Error> {
         Subcommand::CreateCacheMap(sub_options) => {
             commands::create_cache_map(options.global, sub_options)?
         }
+        Subcommand::AssetList(sub_options) => commands::asset_list(options.global, sub_options)?,
     }
 
     Ok(())

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,6 +37,9 @@ pub enum Subcommand {
     /// Downloads any packed spritesheets, then generates a file mapping asset
     /// IDs to file paths.
     CreateCacheMap(CreateCacheMapOptions),
+
+    /// Creates a file that lists all assets required by the project.
+    AssetList(AssetListOptions),
 }
 
 #[derive(Debug, StructOpt)]
@@ -106,4 +109,13 @@ pub struct CreateCacheMapOptions {
     /// A path to a file to contain the cache mapping.
     #[structopt(long = "index-file")]
     pub index_file: PathBuf,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct AssetListOptions {
+    pub project_path: Option<PathBuf>,
+
+    /// A path to a file to put the asset list.
+    #[structopt(long = "cache-dir")]
+    pub output: PathBuf,
 }


### PR DESCRIPTION
This command creates a newline-delimited list of assets used by the project for distribution alongside a model.