### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Tarmac Changelog
 
 ## Unreleased Changes
+
+## 0.6.0 (2020-07-09)
 * Added support for automatically retrying image uploads when image names are moderated. ([#26](https://github.com/Roblox/tarmac/issues/26))
 * Added `create-cache-map` subcommand to aid in prepopulating asset caches. ([#38](https://github.com/Roblox/tarmac/pull/38))
 * Added `asset-list` subcommand to generate a plaintext list of referenced asset IDs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "tarmac"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tarmac"
 description = "Resource compiler and asset manager for Roblox projects"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The recommended way to install Tarmac is with [Foreman](https://github.com/rojo-
 Add an entry to the `[tools]` section of your `foreman.toml` file:
 
 ```toml
-foreman = { source = "Roblox/tarmac", version = "0.5.0" }
+foreman = { source = "Roblox/tarmac", version = "0.6.0" }
 ```
 
 ### Installing from GitHub Releases


### PR DESCRIPTION
* Added support for automatically retrying image uploads when image names are moderated. ([#26](https://github.com/Roblox/tarmac/issues/26))
* Added `create-cache-map` subcommand to aid in prepopulating asset caches. ([#38](https://github.com/Roblox/tarmac/pull/38))
* Added `asset-list` subcommand to generate a plaintext list of referenced asset IDs.