### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The recommended way to install Tarmac is with [Foreman](https://github.com/rojo-
 Add an entry to the `[tools]` section of your `foreman.toml` file:
 
 ```toml
-foreman = { source = "Roblox/tarmac", version = "0.7.0" }
+tarmac = { source = "Roblox/tarmac", version = "0.7.0" }
 ```
 
 ### Installing from GitHub Releases


### PR DESCRIPTION
It looks proper to use 'tarmac' instead of 'foreman'